### PR TITLE
sys.stdout.flush hinzugefügt, damit das logging im journalctl mit den richtigen Zeiten geloggt wird

### DIFF
--- a/AusleseSkript.py
+++ b/AusleseSkript.py
@@ -124,6 +124,7 @@ while 1:
         print("Daten ok")
     else:
         print("wrong M-Bus Start, restarting")
+        sys.stdout.flush()
         sleep(2.5)
         ser.flushOutput()
         ser.close()
@@ -155,6 +156,7 @@ while 1:
     except BaseException as err:
         #print("APU: ", format(apdu))
         print("Fehler: ", format(err))
+        sys.stdout.flush()
         continue;
 
     try:
@@ -192,6 +194,7 @@ while 1:
 
     except BaseException as err:
         print("Fehler: ", format(err))
+        sys.stdout.flush()
         continue;    
     
 
@@ -204,6 +207,7 @@ while 1:
                 connected = True
             except:
                 print("Lost Connection to MQTT...Trying to reconnect in 2 Seconds")
+                sys.stdout.flush()
                 time.sleep(2)
                 
 
@@ -223,6 +227,7 @@ while 1:
         print("1.0.2.8.0.255\tWirkenergie Lieferung [kWh]:\t "+str(WirkenergieN))
         print("-------------\tLeistungsfaktor:\t\t "+str(Leistungsfaktor))
         print("-------------\tWirkleistunggesamt [w]:\t\t " + str(MomentanleistungP-MomentanleistungN))
+        sys.stdout.flush()
         
     #MQTT
     if useMQTT:
@@ -290,5 +295,9 @@ while 1:
         print("Es ist ein Fehler aufgetreten.")
         print()
         print("Fehler: ", format(err))
+        sys.stdout.flush()
         sys.exit()
+
+    # After everything flush stdout
+    sys.stdout.flush()
 


### PR DESCRIPTION
Aktuell ist bei mir im SystemD Journal die Einträge nicht mit den wirklichen Zeiten synchron, weil das stdout nicht geflusht wird.

Habe nun flushes hinzugefügt, damit das Log immer sofort übernommen wird.