### PR TITLE
Check für FrameLänge hinzugefügt

### DIFF
--- a/AusleseSkript.py
+++ b/AusleseSkript.py
@@ -129,6 +129,17 @@ while 1:
         ser.close()
         ser.open()
 
+    if frameLen < 200:
+        print("Framelength too short! " + str(frameLen))
+        print("Restarting serial port....")
+        sys.stdout.flush()
+        sleep(2.5)
+        ser.flushOutput()
+        ser.close()
+        ser.open()
+        continue
+
+
     apdu = evn_decrypt(frame,key,systemTitel,frameCounter)
     if apdu[0:4] != "0f80" :
         continue


### PR DESCRIPTION
Ich habe auch das Issue https://github.com/greenMikeEU/SmartMeterEVNSagemcom-T210-D/issues/27 bei mir beobachtet und gesehen, das hier dann statt Framelen 0xfa (=250 dez) in einem Frame mit der korrekten FrameLen ein Fehler drin ist (year 60688 is out of range) und danach die FrameLen nur noch 0x14 (=20 dez) beträgt.

Diese kurzen Frames konnte ich nur durch ein schließen und neu öffnen des Serial Ports bereinigen.